### PR TITLE
Potential fix for code scanning alert no. 36: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "express": "4.18.2",
     "firebase-admin": "12.0.0",
     "jsonwebtoken": "9.0.2",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "express-rate-limit": "^8.0.0"
   },
   "devDependencies": {
     "@types/express": "4.17.21",

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -1,5 +1,6 @@
 import { Router, Request } from 'express';
 import { requireAuth } from '../utils/requireAuth';
+import rateLimit from 'express-rate-limit';
 
 // Extend Express Request type to include user
 interface AuthRequest extends Request {
@@ -8,12 +9,18 @@ interface AuthRequest extends Request {
 
 export const userRouter = Router();
 
-userRouter.get('/me', requireAuth(['user', 'admin', 'paiduser']), (req: AuthRequest, res) => {
+// Rate limiter: maximum 100 requests per 15 minutes
+const userRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+});
+
+userRouter.get('/me', userRateLimiter, requireAuth(['user', 'admin', 'paiduser']), (req: AuthRequest, res) => {
   // Example: Return user profile
   res.json({ user: req.user });
 });
 
-userRouter.put('/me', requireAuth(['user', 'admin', 'paiduser']), (req: AuthRequest, res) => {
+userRouter.put('/me', userRateLimiter, requireAuth(['user', 'admin', 'paiduser']), (req: AuthRequest, res) => {
   // Example: Update user profile
   res.json({ success: true });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/36](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/36)

To fix the issue, we need to implement rate limiting for the `/me` endpoints (`GET` and `PUT`) in the `userRouter`. This can be achieved using the `express-rate-limit` middleware, a widely-used library for rate limiting in Express applications. 

The implementation steps are as follows:
1. Import the `express-rate-limit` library.
2. Define a rate limiter configuration to limit the number of requests.
   - For example, allow up to 100 requests per 15 minutes per IP.
3. Apply the rate limiter specifically to the `/me` routes to avoid impacting the rest of the application.

This ensures the `/me` endpoints are protected against excessive request rates without altering their core functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
