### PR TITLE
Potential fix for code scanning alert no. 86: Missing rate limiting

### DIFF
--- a/tools/services/backend-api/src/routes/authRoutes.ts
+++ b/tools/services/backend-api/src/routes/authRoutes.ts
@@ -45,7 +45,13 @@ router.post('/register', authController.register);
 router.post('/login', authenticateToken, authController.login);
 
 // ... (logout and getCurrentUser routes remain the same, relying on authenticateToken) ...
-router.post('/logout', authenticateToken, authController.logout);
+const logoutRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50, // limit each IP to 50 requests per windowMs for logout
+    message: { error: 'Too many logout requests, please try again later.' },
+});
+
+router.post('/logout', logoutRateLimiter, authenticateToken, authController.logout);
 import rateLimit from 'express-rate-limit';
 
 const meRateLimiter = rateLimit({

--- a/tools/services/risk-calculation-engine/src/risk_assessment_engine.py
+++ b/tools/services/risk-calculation-engine/src/risk_assessment_engine.py
@@ -3,7 +3,7 @@ import logging
 import time
 from typing import Dict, Any, Optional, List, Tuple
 from dataclasses import dataclass, field
-import numpy as np
+
 import pandas as pd
 import requests
 from sklearn.linear_model import LinearRegression


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/86](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/86)

To address the issue, the `/logout` route should be protected with rate limiting using the `express-rate-limit` middleware. A new rate limiter configuration should be created (or an existing one reused, if appropriate) to restrict the number of requests to this route within a specific time window. The rate limiter should be applied before the `authenticateToken` middleware to minimize the processing of unauthorized or excessive requests.

Steps to fix:
1. Define a new rate limiter for the `/logout` route in the same way as the existing `meRateLimiter`.
2. Apply the rate limiter to the `/logout` route before the `authenticateToken` middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
