### PR TITLE
Potential fix for code scanning alert no. 39: Missing rate limiting

### DIFF
--- a/tools/services/backend-api/src/routes/authRoutes.ts
+++ b/tools/services/backend-api/src/routes/authRoutes.ts
@@ -40,9 +40,14 @@ router.post('/register', authController.register);
  * security:
  * - bearerAuth: [] # Indicate that this endpoint expects a Bearer token (Firebase ID Token)
  */
-// Apply authenticateToken middleware to the login route as well
-// It will verify the ID token, and if valid, the controller just fetches the profile.
-router.post('/login', authenticateToken, authController.login);
+// Apply rate limiting and authenticateToken middleware to the login route
+const loginRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    message: { error: 'Too many login attempts, please try again later.' },
+});
+
+router.post('/login', loginRateLimiter, authenticateToken, authController.login);
 
 // ... (logout and getCurrentUser routes remain the same, relying on authenticateToken) ...
 router.post('/logout', authenticateToken, authController.logout);


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/39](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/39)

To fix the issue, we will apply a rate-limiting middleware to the `/login` route. This will limit the number of requests an IP address can make to the endpoint within a specified time window, mitigating the risk of DoS attacks. We will use the `express-rate-limit` package, which is already imported in the file, to define a rate limiter specifically for the `/login` route. The rate limiter will allow a maximum of 100 requests per 15-minute window, with a custom error message for clients exceeding the limit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
