### PR TITLE
Potential fix for code scanning alert no. 43: Missing rate limiting

### DIFF
--- a/tools/services/backend-api/src/routes/simulationRoutes.ts
+++ b/tools/services/backend-api/src/routes/simulationRoutes.ts
@@ -1,6 +1,7 @@
 // beginnerinvestorhub/tools/services/backend-api/src/routes/simulationRoutes.ts
 
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import * as simulationController from '../controllers/simulationController';
 import { authenticateToken } from '../middleware/authMiddleware'; // Assuming you'll create this middleware
 
@@ -58,7 +59,14 @@ router.post('/run', authenticateToken, simulationController.runPortfolioSimulati
  * 500:
  * description: Internal server error
  */
-router.get('/history', authenticateToken, simulationController.getHistoricalSimulations);
+// Define rate limiter: maximum of 100 requests per 15 minutes
+const rateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: 'Too many requests from this IP, please try again later.'
+});
+
+router.get('/history', authenticateToken, rateLimiter, simulationController.getHistoricalSimulations);
 
 /**
  * @swagger


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/43](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/43)

To address the issue, a rate-limiting middleware should be applied to the `/history` route. The `express-rate-limit` package can be used to implement this. Specifically:
1. Import `express-rate-limit` into the file.
2. Define a rate limiter configuration. For example, limit the number of requests per window (e.g., 100 requests every 15 minutes).
3. Apply the rate limiter middleware to the `/history` route.

This ensures the `/history` endpoint is protected against denial-of-service attacks without affecting functionality or other routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
