### PR TITLE
Potential fix for code scanning alert no. 51: Syntax error

### DIFF
--- a/tools/packages/ui/src/index.ts
+++ b/tools/packages/ui/src/index.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
-export const Button: React.FC<React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>> = ({ children, ...props }) => (
-  <button {...props} style={{ padding: '0.5rem 1rem', background: '#4ECDC4', color: '#fff', border: 'none', borderRadius: 4 }}>
-    {children}
-  </button>
-);
+export const Button: React.FC<React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>> = ({ children, ...props }) => {
+  return (
+    <button {...props} style={{ padding: '0.5rem 1rem', background: '#4ECDC4', color: '#fff', border: 'none', borderRadius: 4 }}>
+      {children}
+    </button>
+  );
+};


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/51](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/51)

To resolve the syntax error, we need to ensure the TypeScript JSX syntax is correct for the `Button` component. 

- The likely cause of the error is that the TypeScript parser may be misinterpreting the type definition (`React.FC<React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>>`) or the JSX syntax following it.
- A possible solution is to explicitly define the types or simplify the type annotation to ensure it is compatible with TypeScript JSX parsing.
- Update the type definition and ensure the JSX structure is valid.

Changes will be made to the file `tools/packages/ui/src/index.ts`. Specifically, the type definition for `Button` will be reviewed and corrected if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
