### PR TITLE
Potential fix for code scanning alert no. 85: Useless comparison test

### DIFF
--- a/tools/apps/web/src/app/(tools)/risk-assessment/page.tsx
+++ b/tools/apps/web/src/app/(tools)/risk-assessment/page.tsx
@@ -96,7 +96,7 @@ async function RiskAssessmentContent() {
           <p className="text-lg text-gray-700 dark:text-gray-300 mb-8">
             Based on your answers, your current risk score indicates you are a{' '}
             <span className="font-semibold text-blue-600 dark:text-blue-400">
-              {sampleRiskScore > 70 ? 'Aggressive Investor' : 'Moderate Investor'}
+              Moderate Investor
             </span>.
           </p>
           <Button className="py-3 px-6 text-lg">


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/85](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/85)

To fix this issue, the redundant condition should be removed. Since the `sampleRiskScore` variable is hardcoded as `65`, the corresponding branch of the conditional statement that depends on the condition `sampleRiskScore > 70` should be simplified or updated to reflect the actual value. If the condition is intended to remain for future dynamic values of `sampleRiskScore`, a comment should be added to clarify its purpose.

Specifically, the conditional operator on line 99 should be replaced with a static string that matches the outcome of the condition (i.e., `'Moderate Investor'`), or the code should be updated to dynamically compute `sampleRiskScore` if such functionality is expected in the future.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
