### PR TITLE
Potential fix for code scanning alert no. 7: First parameter of a method is not named 'self'

### DIFF
--- a/tools/services/market-data-ingestion/src/config.py
+++ b/tools/services/market-data-ingestion/src/config.py
@@ -146,7 +146,7 @@ class Settings(BaseSettings):
         return v
     
     @validator("celery_accept_content")
-    def validate_celery_accept_content(cls, v):
+    def validate_celery_accept_content(self, v):
         if isinstance(v, str):
             return [c.strip() for c in v.split(",")]
         return v


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/7](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/7)

To fix the issue, the first parameter of the `validate_celery_accept_content` method should be renamed from `cls` to `self`, as this is an instance-level method intended to validate field values for specific instances of the `Settings` class. The method itself does not require any other changes, as functionality is unaffected by the change in parameter name.

#### Steps:
1. Locate the `validate_celery_accept_content` method definition on line 149.
2. Rename the first parameter from `cls` to `self`.
3. Ensure no other part of the code referencing this method or its parameters requires adjustments, as the parameter name change is internal to the method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
