### PR TITLE
Potential fix for code scanning alert no. 94: Syntax error

### DIFF
--- a/tools/packages/ui/src/index.ts
+++ b/tools/packages/ui/src/index.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export const Button: React.FC<React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>> = ({ children, ...props }) => {
   return (
-    <button {...props} style={{ padding: '0.5rem 1rem', background: '#4ECDC4', color: '#fff', border: 'none', borderRadius: 4 }}>
+    <button {...props} style={{ padding: '0.5rem 1rem', backgroundColor: '#4ECDC4', color: '#fff', border: 'none', borderRadius: '4px' }}>
       {children}
     </button>
   );


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/94](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/94)

To fix the syntax error, we need to ensure that the JSX syntax and type annotations are correct. The error "Error: '>' expected" suggests that the TypeScript parser is expecting a closing angle bracket (`>`) for a type annotation or JSX element. This can happen if the type annotations are malformed or if there is a mismatch in the JSX syntax.

The best way to fix this issue is to verify the type annotations for the `Button` component and ensure that the JSX syntax is valid. Specifically:
1. Check the type annotations for `React.FC<React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>>` to ensure they are correctly formatted.
2. Ensure the JSX syntax for the `<button>` element is valid and properly closed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
