### PR TITLE
Potential fix for code scanning alert no. 136: Unused import

### DIFF
--- a/tools/services/shared/utils/logging.py
+++ b/tools/services/shared/utils/logging.py
@@ -289,7 +289,7 @@ def log_business_event(
 # ==============================================================================
 
 import time
-from fastapi import Request, Response
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/136](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/136)

To fix the issue, we will remove the unused `Response` import from the `fastapi` module. This will eliminate the unnecessary dependency and improve code clarity. The change will be made on line 292, where the `Response` class is imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
