### PR TITLE
Potential fix for code scanning alert no. 164: Property access on null or undefined

### DIFF
--- a/backend/src/middleware/swagger.ts
+++ b/backend/src/middleware/swagger.ts
@@ -241,7 +241,7 @@ export const serveOpenApiSpec = (req: Request, res: Response) => {
         ...openApiSpec,
         servers: [
             { url: baseUrl, description: 'Current server' },
-            ...(openApiSpec.servers || [])
+            ...(openApiSpec.servers ?? [])
         ]
     };
     


### PR DESCRIPTION
Potential fix for [https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/164](https://github.com/Beginnerinvestorhub/Tools/security/code-scanning/164)

To fix the issue, we need to ensure that `openApiSpec.servers` is safely accessed. If `openApiSpec.servers` is `undefined`, we should default it to an empty array to prevent runtime errors. This can be achieved using the nullish coalescing operator (`??`) or a similar fallback mechanism.

The specific change will involve modifying line 244 to safely handle the case where `openApiSpec.servers` is `undefined`. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
